### PR TITLE
provide custom network interface parameter to etherwake

### DIFF
--- a/server/core/WakeOnLan/etherwake.js
+++ b/server/core/WakeOnLan/etherwake.js
@@ -1,14 +1,15 @@
 'use strict';
-const cp = require('child_process');
+const _ = require('lodash'),
+  cp = require('child_process');
 
 const sanitizeMacAddress = string => string.split(':', 6).map(o => parseInt(o, 16)).map(o => o.toString(16)).join(':');
 
-exports = module.exports = macAddress => new Promise((resolve, reject) => {
+exports = module.exports = (macAddress, options) => new Promise((resolve, reject) => {
   const sanitizedMacAddress = sanitizeMacAddress(macAddress);
   if ('NaN' === sanitizedMacAddress) {
     return reject(new Error(`invalid MAC address: '${macAddress}'`));
   }
-  cp.spawn('etherwake', [sanitizedMacAddress], {stdio: 'ignore'})
+  cp.spawn('etherwake', ['-i', _.get(options, 'iface', 'eth0'), sanitizedMacAddress], {stdio: 'ignore'})
     .on('error', reject)
     .on('exit', () => resolve());
 });

--- a/server/env.js
+++ b/server/env.js
@@ -7,4 +7,5 @@ exports = module.exports = {
   defaultThrottleInterface: () => _.get(process.env, 'DEFAULT_THROTTLE_INTERFACE', 'eth0'),
   defaultThrottleBandwidth: () => _.get(process.env, 'DEFAULT_THROTTLE_BANDWIDTH', '5mbit'),
   tokenIssuerUri: () => _.get(process.env, 'TOKEN_ISSUER_URI'),
+  wakeOnLanInterface: () => _.get(process.env, 'WAKE_ON_LAN_INTERFACE', 'eth0'),
 };

--- a/server/routes/wakeupHost.js
+++ b/server/routes/wakeupHost.js
@@ -1,5 +1,6 @@
 'use strict';
 const _ = require('lodash'),
+  env = require('../env'),
   core = require('../core'),
   HttpError = require('http-error-constructor');
 
@@ -8,7 +9,7 @@ exports = module.exports = (req, res, next) => {
   if (!hwaddr) {
     return Promise.resolve(next(new HttpError(400)));
   }
-  return core.WakeOnLan.etherwake(hwaddr)
+  return core.WakeOnLan.etherwake(hwaddr, {iface: env.wakeOnLanInterface()})
     .then(() => res.sendStatus(204))
     .catch(err => {
       if (err.message.startsWith('invalid MAC')) {


### PR DESCRIPTION
Fixes #25
Adds new optional environment variable: `WAKE_ON_LAN_INTERFACE=eth0`